### PR TITLE
Fix mojibake for non-ASCII paste output (pbcopy UTF-8 locale)

### DIFF
--- a/clipboard/clipboard_darwin.go
+++ b/clipboard/clipboard_darwin.go
@@ -11,6 +11,8 @@ static int testAccessibility() {
 import "C"
 
 import (
+	"os"
+	"strings"
 	"sync"
 
 	"github.com/micmonay/keybd_event"
@@ -21,6 +23,23 @@ var (
 	kbOnce sync.Once
 	kbErr  error
 )
+
+// ensureUTF8Locale guarantees pbcopy/pbpaste interpret text as UTF-8.
+// GUI apps launched from Finder inherit no LANG/LC_CTYPE, so pbcopy falls
+// back to a legacy encoding and mangles multi-byte characters (e.g. Turkish
+// ğ ş ı İ ç ö ü). Setting LC_CTYPE to a UTF-8 locale fixes this for the child
+// process that atotto/clipboard exec's. We only override when the current
+// ctype locale is not already UTF-8, so an explicit tr_TR.UTF-8 etc. is kept.
+func init() {
+	isUTF8 := func(v string) bool {
+		v = strings.ToLower(v)
+		return strings.Contains(v, "utf-8") || strings.Contains(v, "utf8")
+	}
+	if isUTF8(os.Getenv("LC_ALL")) || isUTF8(os.Getenv("LC_CTYPE")) || isUTF8(os.Getenv("LANG")) {
+		return
+	}
+	os.Setenv("LC_CTYPE", "en_US.UTF-8")
+}
 
 func Init() error {
 	kbOnce.Do(func() {


### PR DESCRIPTION
Fixes #25.

## Problem
Auto-pasted transcriptions corrupt non-ASCII characters. Turkish is a clear example:

```
güzel çünkü şışı İğne öüç   →   g√ºzel √ß√ºnk√º ≈üƒ±≈üƒ± ƒ∞ƒüne √∂√º√ß
```

## Cause
`clipboard.Copy` uses `github.com/atotto/clipboard`, which shells out to `pbcopy` on macOS. `pbcopy` decodes stdin using the process `LC_CTYPE`/`LANG` locale. A GUI app launched from Finder/LaunchServices inherits **no** `LANG`/`LC_CTYPE`, so `pbcopy` falls back to a legacy (MacRoman) encoding and misreads the UTF-8 bytes Go writes.

Verified independently of the app:
```sh
printf 'güzel çünkü şışı İğne öüç' | env -i /usr/bin/pbcopy      # like a Finder-launched app
LANG=en_US.UTF-8 pbpaste                                          # -> mojibake

printf 'güzel çünkü şışı İğne öüç' | env LC_CTYPE=en_US.UTF-8 /usr/bin/pbcopy
LANG=en_US.UTF-8 pbpaste                                          # -> correct
```

## Fix
Add an `init()` in `clipboard/clipboard_darwin.go` that sets `LC_CTYPE=en_US.UTF-8` before `pbcopy` is ever exec'd — **only** when the current ctype locale isn't already UTF-8, so an explicit `tr_TR.UTF-8` (or any UTF-8 locale) is preserved. Minimal, no new dependencies, affects both batch and streaming paste paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gLjrqJZv1i1Zh4HYwwmh5